### PR TITLE
Fixed time zones and microsecond precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ now -e -p s
 now -e -p ms
 ```
 
+### UNIX Epoch Time in Microseconds
+
+```shell
+now -e -p us
+```
+
 ### UNIX Epoch Time in Nanoseconds
 
 ```shell

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -19,6 +19,10 @@ testEpochMilliseconds() {
   "${DIR}/../bin/now" -e -p ms
 }
 
+testEpochMicroseconds() {
+  "${DIR}/../bin/now" -e -ps us
+}
+
 testEpochNanoseconds() {
   "${DIR}/../bin/now" -e -p ns
 }
@@ -37,6 +41,14 @@ testRFC3339() {
 
 testYearMonthDay() {
   "${DIR}/../bin/now" -f 2006-01-02
+}
+
+testTimeZoneFixed() {
+  "${DIR}/../bin/now" -z UTC+09:30
+}
+
+testTimeZoneNamed() {
+  "${DIR}/../bin/now" -z America/New_York
 }
 
 oneTimeSetUp() {


### PR DESCRIPTION
Closes #1 

Adds support for fixed times zones and microsecond precision when printing the Unix epoch timestamp.